### PR TITLE
Alter Plasma Beam Room's requirements

### DIFF
--- a/app/Region/SuperMetroid/Maridia/Inner.php
+++ b/app/Region/SuperMetroid/Maridia/Inner.php
@@ -79,7 +79,7 @@ class Inner extends Region {
         $this->locations["Plasma Beam"]->setRequirements(function($location, $items) {
             return $items->canDefeatDraygon()
                 && ($items->has('SpeedBooster')
-                 || (($items->has('ChargeBeam') || $items->has('ScrewAttack')) && ($items->canFlySM() || $items->has('HiJump'))));                 
+                 || ((($items->has('ChargeBeam') && ($items->hasEnergyReserves(4) || ($items->has('Varia') && $items->hasEnergyReserves(1)))) || $items->has('Plasma') || $items->has('ScrewAttack')) && ($items->canFlySM() || $items->has('HiJump'))));                 
 		});
 
         $this->locations["Power Bomb (right Maridia sand pit room)"]->setRequirements(function($location, $items) {

--- a/app/Region/SuperMetroid/Maridia/Inner.php
+++ b/app/Region/SuperMetroid/Maridia/Inner.php
@@ -79,7 +79,7 @@ class Inner extends Region {
         $this->locations["Plasma Beam"]->setRequirements(function($location, $items) {
             return $items->canDefeatDraygon()
                 && ($items->has('SpeedBooster')
-                 || ((($items->has('ChargeBeam') && ($items->hasEnergyReserves(4) || ($items->has('Varia') && $items->hasEnergyReserves(1)))) || $items->has('Plasma') || $items->has('ScrewAttack')) && ($items->canFlySM() || $items->has('HiJump'))));                 
+                 || ((($items->has('ChargeBeam') && ($items->hasEnergyReserves(6) || ($items->has('Varia') && $items->hasEnergyReserves(1)))) || $items->has('Plasma') || $items->has('ScrewAttack')) && ($items->canFlySM() || $items->has('HiJump'))));                 
 		});
 
         $this->locations["Power Bomb (right Maridia sand pit room)"]->setRequirements(function($location, $items) {


### PR DESCRIPTION
Charged Pseudo-Screw needs more energy to be able to defeat the limited-vulnerability pirates.
Varia's damage-reduction trims down that requirement a bit.
Add intended method of using Plasma Beam for hopefully more randomness possibilities.