### PR TITLE
Update E-tank in Mama Turtle room tournament logic

### DIFF
--- a/app/Region/SuperMetroid/Maridia/Outer.php
+++ b/app/Region/SuperMetroid/Maridia/Outer.php
@@ -57,8 +57,9 @@ class Outer extends Region {
 		});
 
         $this->locations["Energy Tank, Mama turtle"]->setRequirements(function($location, $items) {
-            return $items->canFlySM() || $items->has('SpeedBooster') || $items->has('Grapple') || $items->canSpringBallJump();        
-		});
+            return $items->canFlySM() || $items->has('Grapple') || $items->canSpringBallJump()
+		|| ($items->has('Gravity') && $items->has('SpeedBooster'));
+                });
 
         $this->can_enter = function($locations, $items) {
             return ($this->world->getRegion('West Norfair')->canEnter($locations, $items)


### PR DESCRIPTION
The tournament logic lists speedbooster as one of the possible requirements but without gravity suit, speedbooster cannot be used.

I made an issue about it at #42 because I'm not fully sure that this is an error, perhaps I missed a condition that implies that you have gravity already, but I didn't see one, so I made this PR just in case! Feel free to close if this isn't needed.

Thanks for the awesome randomizer