### PR TITLE
Update Maridia left sand pit in tournament logic to include Spring Ball and Hijump if suitless

### DIFF
--- a/app/Region/SuperMetroid/Maridia/Inner.php
+++ b/app/Region/SuperMetroid/Maridia/Inner.php
@@ -95,11 +95,11 @@ class Inner extends Region {
 		});
 
 		$this->locations["Missile (left Maridia sand pit room)"]->setRequirements(function($location, $items) {
-			return $items->has('HiJump') || $items->has('Gravity');
+			return ($items->has('HiJump') && $items->canSpringBallJump()) || $items->has('Gravity');
 		});
 
 		$this->locations["Reserve Tank, Maridia"]->setRequirements(function($location, $items) {
-			return $items->has('HiJump') || $items->has('Gravity');
+			return ($items->has('HiJump') && $items->canSpringBallJump()) || $items->has('Gravity');
 		});
 
 		$this->locations["Missile (right Maridia sand pit room)"]->setRequirements(function($location, $items) {


### PR DESCRIPTION
getting maridia's items in the left sand pit suitless with hijumpis incredibly difficult compared to most tricks required in tournament logic, and as noted in #47, borderline TAS. requiring spring ball as well makes this much more reasonable

addresses issue #47