### PR TITLE
Alter Casual Super Missile (Crateria)

### DIFF
--- a/app/Region/SuperMetroid/Crateria/Central.php
+++ b/app/Region/SuperMetroid/Crateria/Central.php
@@ -96,7 +96,7 @@ class Central extends Region {
 		});
 
 		$this->locations["Super Missile (Crateria)"]->setRequirements(function($location, $items) {
-			return $items->canUsePowerBombs() && $items->hasEnergyReserves(2) && $items->has('SpeedBooster');
+			return $items->canUsePowerBombs() && $items->hasEnergyReserves(2) && $items->has('SpeedBooster') && $items->has('IceBeam');
 		});
 
 		$this->locations["Bombs"]->setRequirements(function($location, $items) {


### PR DESCRIPTION
Add Ice Beam as access requirement for Casual Logic for Super Missile (Crateria).
Addresses #50 and #37.
