### PR TITLE
Updating Crateria East

### DIFF
--- a/app/Region/SuperMetroid/Crateria/East.php
+++ b/app/Region/SuperMetroid/Crateria/East.php
@@ -78,7 +78,7 @@ class East extends Region {
 	public function initCasual() {
 
 		$this->locations["Missile (outside Wrecked Ship bottom)"]->setRequirements(function($location, $items) {
-			return ($items->has('SpeedBooster') || $items->has('Grapple') || $items->has('SpaceJump') || $items->canSpringBallJump() || $items->canAccessMaridiaPortal());
+			return ($items->has('SpeedBooster') || $items->has('Grapple') || $items->has('SpaceJump') || $items->canAccessMaridiaPortal());
 		});
 
 		$this->locations["Missile (outside Wrecked Ship top)"]->setRequirements(function($location, $items) {


### PR DESCRIPTION
Removed the requirement of Springball jumping across the moat on normal logic, for the following reasons:
1) You have to maintain momentum much like Mockball, which is NOT REQUIRED by normal logic.
2) It is rather tight execution, which is akin to the walljumps to get up to Gauntlet or Alcatraz Escape, which is NOT REQUIRED by normal logic.
3) The game does not teach you horizontal springball jumps, which is the basis of the tech needed for normal logic.