### PR TITLE
Updated Crocomire access

### DIFF
--- a/app/Region/SuperMetroid/Norfair/Crocomire.php
+++ b/app/Region/SuperMetroid/Norfair/Crocomire.php
@@ -124,7 +124,9 @@ class Crocomire extends Region {
                 || $items->canAccessNorfairPortal())
                 && $items->has('Varia')
 				&& $items->has('Super')
-				&& (($items->canUsePowerBombs() && $items->has('SpeedBooster')) || ($items->has('SpeedBooster') && $items->has('Wave')) || ($items->has('Morph') && ($items->canFlySM() || $items->has('HiJump')) && $items->has('Wave')));
+				&& (($items->canUsePowerBombs() && $items->has('SpeedBooster'))
+				    || ($items->has('SpeedBooster') && $items->has('Wave'))
+				    || ($items->has('Morph') && ($items->canFlySM() || $items->has('HiJump')) && $items->has('Gravity') && $items->has('Wave')));
         };
 
 		return $this;


### PR DESCRIPTION
Apparently in Normal Logic, you can be expected to take lava (environmental) damage to get to Croc if you don't have bombs. Added in a Gravity Suit check to account for that.